### PR TITLE
[KAN-231] Implement catalog models into the codebase and migrate them into the database

### DIFF
--- a/backend/catalog/models.py
+++ b/backend/catalog/models.py
@@ -1,21 +1,129 @@
 from django.db import models
 
 
-class Game(models.Model):
+class BGGAttribute(models.Model):
     """
-    Placeholder model until the XML structure from BGG XML API2 can be confirmed.
+    A base class for BGG metadata linking. Serves as a template for Many-To-Many metadata tags returned by the BGG XML
+    API2 <link> nodes.
 
-    Acts as a local cache for BoardGameGeek data to minimize API requests.
+    Note:
+        - 'abstract = True' ensures Django does not create a database table for this class, only for classes that
+        inherit from it. Do not remove this attribute.
     """
+
     bgg_id = models.IntegerField(primary_key=True)
     name = models.CharField(max_length=255)
-    bgg_rank = models.IntegerField(null=True, blank=True)
-    bgg_average_rating = models.FloatField(null=True, blank=True)
+
+    class Meta:
+        abstract = True
 
     def __str__(self):
         """
-        Return the string representation of the Game.
+        Returns the string representation of the attribute.
 
-        :returns: The name of the board game.
+        :returns: The name associated with an attribute from the BGG API.
         """
         return self.name
+
+
+class Category(BGGAttribute):
+    """
+    Represent a boardgame category. Inherits all data from BGGAttribute.
+
+    Notes:
+        - Extracted from BGG XML nodes matching: <link type="boardgamecategory">.
+    """
+    pass
+
+
+class Mechanic(BGGAttribute):
+    """
+    Represent a gameplay mechanic. Inherits all data from BGGAttribute.
+
+    Notes:
+        - Extracted from BGG XML nodes matching: <link type="boardgamemechanic">.
+    """
+    pass
+
+
+class Publisher(BGGAttribute):
+    """
+    Represent a boardgame's publisher. Inherits all data from BGGAttribute.
+
+    Notes:
+        - Extracted from BGG XML nodes matching: <link type="boardgamepublisher">.
+    """
+    pass
+
+
+class Designer(BGGAttribute):
+    """
+    Represent a boardgame's designer. Inherits all data from BGGAttribute.
+
+    Notes:
+        - Extracted from BGG XML nodes matching: <link type="boardgamedesigner">.
+    """
+    pass
+
+
+class Artist(BGGAttribute):
+    """
+    Represent a boardgame's artist. Inherits all data from BGGAttribute.
+
+    Notes:
+        - Extracted from BGG XML nodes matching: <link type="boardgameartist">.
+    """
+    pass
+
+
+class Family(BGGAttribute):
+    """
+    Represent a boardgame family. Inherits all data from BGGAttribute.
+
+    Notes:
+        - Extracted from BGG XML nodes matching: <link type="boardgamefamily">.
+    """
+    pass
+
+
+class BoardGame(models.Model):
+    """
+    Represents the <item type="boardgame"> object from the BGG XML API2.
+    """
+
+    bgg_id = models.IntegerField(primary_key=True)
+    primary_name = models.CharField(max_length=255)
+    description = models.TextField(blank=True, null=True)
+    year_published = models.IntegerField(null=True, blank=True)
+
+    minimum_players = models.IntegerField(null=True, blank=True)
+    maximum_players = models.IntegerField(null=True, blank=True)
+
+    playing_time = models.IntegerField(null=True, blank=True)
+    minimum_playtime = models.IntegerField(null=True, blank=True)
+    maximum_playtime = models.IntegerField(null=True, blank=True)
+
+    minimum_age = models.IntegerField(null=True, blank=True)
+
+    thumbnail_url = models.URLField(max_length=500, null=True, blank=True)
+    image_url = models.URLField(max_length=500, null=True, blank=True)
+
+    # Relationship (<link> tags)
+    categories = models.ManyToManyField(Category, related_name='games', blank=True)
+    mechanics = models.ManyToManyField(Mechanic, related_name='games', blank=True)
+    publishers = models.ManyToManyField(Publisher, related_name='games', blank=True)
+    designers = models.ManyToManyField(Designer, related_name='games', blank=True)
+    artists = models.ManyToManyField(Artist, related_name='games', blank=True)
+    families = models.ManyToManyField(Family, related_name='games', blank=True)
+
+    # Stats
+    average_rating = models.DecimalField(max_digits=5, decimal_places=3, null=True, blank=True)
+    bgg_rank = models.IntegerField(null=True, blank=True)
+
+    def __str__(self):
+        """
+        Return the string representation of a boardgame's name and year of publication
+
+        :return: A string containing the name and publication year for a board game.
+        """
+        return f"{self.primary_name} ({self.year_published})"

--- a/backend/catalog/models.py
+++ b/backend/catalog/models.py
@@ -17,7 +17,7 @@ class BGGAttribute(models.Model):
     class Meta:
         abstract = True
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Returns the string representation of the attribute.
 
@@ -120,7 +120,7 @@ class BoardGame(models.Model):
     average_rating = models.DecimalField(max_digits=5, decimal_places=3, null=True, blank=True)
     bgg_rank = models.IntegerField(null=True, blank=True)
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Return the string representation of a boardgame's name and year of publication
 

--- a/backend/catalog/models.py
+++ b/backend/catalog/models.py
@@ -127,3 +127,5 @@ class BoardGame(models.Model):
         :return: A string containing the name and publication year for a board game.
         """
         return f"{self.primary_name} ({self.year_published})"
+
+# skibidi doo dah grimes, you guys actually reading this PR?

--- a/backend/profiles/models.py
+++ b/backend/profiles/models.py
@@ -23,7 +23,7 @@ class Profile(models.Model):
     privacy_level = models.CharField(max_length=10, choices=PRIVACY_LEVEL_CHOICES, default=PUBLIC)
     friends = models.ManyToManyField(to='self', blank=True)
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Return the string representation of the user's Profile.
 
@@ -44,7 +44,7 @@ class GameGroup(models.Model):
                                    related_name='created_groups')
     members = models.ManyToManyField(to=settings.AUTH_USER_MODEL, related_name='group_memberships')
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Return the string representation of the game group.
 
@@ -73,7 +73,7 @@ class PlayerTag(models.Model):
     class Meta:
         unique_together = ('assigning_user', 'target_user', 'tag_type')
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Return the string representation of the PlayerTag.
 

--- a/backend/tracking/models.py
+++ b/backend/tracking/models.py
@@ -22,7 +22,7 @@ class LibraryItem(models.Model):
     status = models.CharField(max_length=20, choices=LIBRARY_ENTRY_STATUSES, default=UNPLAYED)
     house_rules = models.TextField(null=True, blank=True)
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Return the string representation of the LibraryItem.
 
@@ -45,7 +45,7 @@ class Rating(models.Model):
     class Meta:
         unique_together = ['user', 'game']
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Return the string representation of the Rating.
 
@@ -63,7 +63,7 @@ class PlaySession(models.Model):
     play_date = models.DateField()
     play_time_minutes = models.IntegerField()
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Return the string representation of the PlaySession.
 
@@ -81,7 +81,7 @@ class SessionPlayer(models.Model):
     score = models.FloatField()
     is_winner = models.BooleanField()
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Return the string representation of the SessionPlayer.
 


### PR DESCRIPTION
### Pull Request Purpose
This PR updates the previous placeholder model in the catalog app. The new models now match the XML response we will receive from the BGG XML API2.

### Code Change Summary
- Added the main BoardGame model and all necessary attributes.
- Added base BGGAttribute model to link metadata to a board game. Examples of this metadata include categories, publishers, etc.
- Added child models for different attributes.
- Added typehints for various `__str__(self)` functions that slipped through the PR for KAN-36

### Notes
Documentation in Confluence has also been updated to reflect the changes of this PR. I will create another story and PR for the migration of these models into the database.