### PR TITLE
Feature/frontend docker integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+## Frontend Docker Setup
+
+The Questlog frontend is a Next.js application located in the `frontend/` directory.
+
+### Build the frontend image
+
+From the project root, build the frontend Docker image with:
+
+```bash
+docker build -t questlog-frontend-test ./frontend
+```
+
+### Run the frontend container
+
+Run the container and expose the Next.js application on port 3000:
+
+```bash
+docker run --rm -p 3000:3000 questlog-frontend-test
+```
+
+The frontend can then be accessed at:
+
+```text
+http://localhost:3000
+```
+
+### Frontend environment variables
+
+Frontend environment variables are documented in:
+
+```text
+frontend/.env.example
+```
+
+Copy the example file when configuring a local frontend environment. Do not commit real environment files or secrets.
+
+The frontend Docker image is designed to integrate with the project's Docker Compose environment so that the frontend can run alongside the backend and database services.

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+.next
+.env
+.env.local
+.env.*
+!.env.example
+!.env.local.example
+npm-debug.log*
+.DS_Store
+coverage

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,8 @@
+# Public URL used by the browser to communicate with Django
+NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# Internal Docker URL used for server-side communication
+INTERNAL_API_URL=http://backend:8000
+
+# Public URL for the Next.js frontend
+NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,6 +32,8 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
+!.env.local.example
 
 # vercel
 .vercel

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:22-alpine AS deps
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+RUN npm run build
+
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/package-lock.json ./package-lock.json
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+
+EXPOSE 3000
+
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
Added some frontend portions of the single-command Docker environment. Added the necessary files and updated the frontend. gitignore to allow environment example files. 

The Docker configuration for our frontend should be able to integrate with our Docker Compose setup. Full-stack Compose verification depends on the backend Docker configuration being available in the shared integration branch. 
Closes #21 